### PR TITLE
Fixing the crash about connecting by the wrong way to a port

### DIFF
--- a/src/parsing/ServerConfig.cpp
+++ b/src/parsing/ServerConfig.cpp
@@ -6,7 +6,7 @@
 /*   By: beboccas <beboccas@student.42lausanne.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/05 15:07:41 by beboccas          #+#    #+#             */
-/*   Updated: 2025/11/14 03:07:38 by beboccas         ###   ########.fr       */
+/*   Updated: 2025/11/14 03:10:52 by beboccas         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ ServerConfig WebServ::getServer(std::string hostReq)
 			return servers[i];
 	}
 	std::cout << "No server matches the requested host:" << hostReq << ". Returning the first one." << std::endl;
-	return servers[0];//return first server as default
+	return emptyServer;//return first server as default
 	
 }
 

--- a/src/parsing/ServerConfig.cpp
+++ b/src/parsing/ServerConfig.cpp
@@ -6,7 +6,7 @@
 /*   By: beboccas <beboccas@student.42lausanne.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/05 15:07:41 by beboccas          #+#    #+#             */
-/*   Updated: 2025/11/14 03:03:50 by beboccas         ###   ########.fr       */
+/*   Updated: 2025/11/14 03:07:38 by beboccas         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,13 @@ ServerConfig WebServ::getServer(std::string hostReq)
 	for (size_t i = 0; i < servers.size(); ++i)
 	{
 		serverHostPort = servers[i].server_name + ":" + toString(servers[i].listen_port);
+		if (serverHostPort == hostReq)
+			return servers[i];
+	}
+	for (size_t i = 0; i < servers.size(); ++i)
+	{
+		//if no exact match found, try to match only by port
+		serverHostPort = ":" + toString(servers[i].listen_port);
 		if (serverHostPort == hostReq)
 			return servers[i];
 	}

--- a/src/parsing/ServerConfig.cpp
+++ b/src/parsing/ServerConfig.cpp
@@ -6,7 +6,7 @@
 /*   By: beboccas <beboccas@student.42lausanne.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/05 15:07:41 by beboccas          #+#    #+#             */
-/*   Updated: 2025/11/12 15:03:24 by beboccas         ###   ########.fr       */
+/*   Updated: 2025/11/14 03:03:50 by beboccas         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,8 +46,8 @@ ServerConfig WebServ::getServer(std::string hostReq)
 		if (serverHostPort == hostReq)
 			return servers[i];
 	}
-	std::cout << "No server matches the requested host:" << hostReq << std::endl;
-	return emptyServer;
+	std::cout << "No server matches the requested host:" << hostReq << ". Returning the first one." << std::endl;
+	return servers[0];//return first server as default
 	
 }
 


### PR DESCRIPTION
I just checked nginx and i found wierd that the server crashes if the wrong IP was given in the URL.
In nginx, if you connect to a valid port by a wrong hostname, it will return the first server block config that uses this port.
I changed that, so now, if the config file says "localhost:2222" and we connect via "127.0.0.1:2222" the server will check thoses things :
-Does "127.0.0.1:2222 exists ?", if yes, return the correct config block.
-If not, check if a server block uses the port 2222. If yes, return the first server block that uses port 2222.
-If not, just return nothing, because basically, you cant connect to a port by another (you cant access port 3333 if you try to connect to the port 2222, so the error is gonna be handled by the client web browser)

PS: I only added Sylvie on the review because it's a problem that is concerning her at the moment. 
PS2: I'll merge the request when reviewed, don't do it manually :+1: 

Have a good weekend ! 